### PR TITLE
create webjar for embedded usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,16 @@
 # top-most EditorConfig file
 root = true
 
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
 [{*.js,*.less,*.json,*.html}]
 indent_style = space
 indent_size = 2

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The structure is as follows:
 
 * `core` - camunda core application and plugin infrastructure
 * `webapp` - camunda web application
+* `webjar` - stripped down webjar for use in embedded containers (like spring boot)
 * `distro/{container}` - projects that produce camunda web application for the different bpm platform containers
 
 ## Webapps

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.camunda.bpm.webapp</groupId>
@@ -25,6 +26,7 @@
         <module>core</module>
         <module>webapp</module>
         <module>test-utility</module>
+        <module>webjar</module>
 
       </modules>
     </profile>

--- a/webjar/pom.xml
+++ b/webjar/pom.xml
@@ -26,6 +26,7 @@
       <artifactId>camunda-webapp</artifactId>
       <version>${project.parent.version}</version>
       <type>war</type>
+      <classifier>classes</classifier>
     </dependency>
   </dependencies>
 

--- a/webjar/pom.xml
+++ b/webjar/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.camunda.bpm.webapp</groupId>
+    <artifactId>camunda-webapp-root</artifactId>
+    <version>7.4.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.camunda.bpm.webapp</groupId>
+  <artifactId>camunda-webapp-webjar</artifactId>
+  <packaging>jar</packaging>
+  <name>camunda BPM - webapp - webjar</name>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <!-- add dependency so this is run after the war was build -->
+  <dependencies>
+    <dependency>
+      <groupId>org.camunda.bpm.webapp</groupId>
+      <artifactId>camunda-webapp</artifactId>
+      <version>${project.parent.version}</version>
+      <type>war</type>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- first fetch and unpack the war -->
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.camunda.bpm.webapp</groupId>
+                  <artifactId>camunda-webapp</artifactId>
+                  <version>${project.parent.version}</version>
+                  <type>war</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                  <excludes>META-INF/**</excludes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- then remove the WEB-INF part except the security.json -->
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <configuration>
+              <target>
+                <move file="${project.build.outputDirectory}/WEB-INF/securityFilterRules.json" todir="${project.build.outputDirectory}"/>
+                <delete dir="${project.build.outputDirectory}/WEB-INF"/>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/webjar/pom.xml
+++ b/webjar/pom.xml
@@ -25,7 +25,7 @@
       <groupId>org.camunda.bpm.webapp</groupId>
       <artifactId>camunda-webapp</artifactId>
       <version>${project.parent.version}</version>
-      <type>war</type>
+      <type>jar</type>
       <classifier>classes</classifier>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This is related to https://github.com/camunda/camunda-bpm-spring-boot-starter/issues/3 where we need a webjar for spring-boot. 

I used zapatas gradle job as a template to create my jar file.

I am confused though, because the jar I create is much smaller than the jar zapatas build creates. When I checked the content, I found out that in my approach there are no views included. Then I checked the 7.4.0-SNAPSHOT war file content and there are no views either. So maybe this is not an error? Would be glad if someone could check this. 