### PR TITLE
Do not build natives npm packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -902,13 +902,14 @@
                     <exec executable="cmd" failonerror="true">
                       <arg value="/c" />
                       <arg value="npm" />
-                      <arg value="install --no-optional" />
+                      <arg value="install" />
+                      <arg value="--no-optional" />
                     </exec>
                     <!--
                     <exec executable="cmd" failonerror="true">
                       <arg value="/c" />
                       <arg value="node_modules\.bin\bower.cmd" />
-                      <arg value="install --no-optional" />
+                      <arg value="install" />
                     </exec>
                     -->
                     <exec executable="cmd" failonerror="true">
@@ -951,11 +952,12 @@
                   <target>
                     <!-- run node build -->
                     <exec executable="npm" failonerror="true">
-                      <arg value="install --no-optional" />
+                      <arg value="install" />
+                      <arg value="--no-optional" />
                     </exec>
                     <!--
                     <exec executable="./node_modules/bower/bin/bower" failonerror="true">
-                      <arg value="install --no-optional" />
+                      <arg value="install" />
                     </exec>
                     -->
                     <exec executable="./node_modules/grunt-cli/bin/grunt" failonerror="true">

--- a/pom.xml
+++ b/pom.xml
@@ -902,13 +902,13 @@
                     <exec executable="cmd" failonerror="true">
                       <arg value="/c" />
                       <arg value="npm" />
-                      <arg value="install" />
+                      <arg value="install --no-optional" />
                     </exec>
                     <!--
                     <exec executable="cmd" failonerror="true">
                       <arg value="/c" />
                       <arg value="node_modules\.bin\bower.cmd" />
-                      <arg value="install" />
+                      <arg value="install --no-optional" />
                     </exec>
                     -->
                     <exec executable="cmd" failonerror="true">
@@ -951,11 +951,11 @@
                   <target>
                     <!-- run node build -->
                     <exec executable="npm" failonerror="true">
-                      <arg value="install" />
+                      <arg value="install --no-optional" />
                     </exec>
                     <!--
                     <exec executable="./node_modules/bower/bin/bower" failonerror="true">
-                      <arg value="install" />
+                      <arg value="install --no-optional" />
                     </exec>
                     -->
                     <exec executable="./node_modules/grunt-cli/bin/grunt" failonerror="true">


### PR DESCRIPTION
Do not need to build natives npm packages if you do not have.
(So no need of gcc or compiler)