### PR TITLE
fix(welcome): add  listeners and servlet configurations

### DIFF
--- a/src/main/runtime/jboss/webapp/WEB-INF/web.xml
+++ b/src/main/runtime/jboss/webapp/WEB-INF/web.xml
@@ -17,6 +17,11 @@
     <listener-class>org.camunda.bpm.tasklist.impl.web.bootstrap.TasklistContainerBootstrap</listener-class>
   </listener>
 
+  <!-- welcome bootstrap listener -->
+  <listener>
+    <listener-class>org.camunda.bpm.welcome.impl.web.bootstrap.WelcomeContainerBootstrap</listener-class>
+  </listener>
+
   <!-- Authentication filter -->
   <filter>
     <filter-name>Authentication Filter</filter-name>
@@ -34,7 +39,7 @@
     <filter-class>org.camunda.bpm.webapp.impl.security.filter.SecurityFilter</filter-class>
     <init-param>
       <param-name>configFile</param-name>
-      <param-value>/WEB-INF/securityFilterRules.json</param-value>  
+      <param-value>/WEB-INF/securityFilterRules.json</param-value>
     </init-param>
   </filter>
   <filter-mapping>
@@ -53,11 +58,11 @@
     <url-pattern>/app/*</url-pattern>
     <dispatcher>REQUEST</dispatcher>
   </filter-mapping>
-  
+
   <!-- REST cache control filter -->
   <filter>
     <filter-name>CacheControlFilter</filter-name>
-    <filter-class>org.camunda.bpm.engine.rest.filter.CacheControlFilter</filter-class>    
+    <filter-class>org.camunda.bpm.engine.rest.filter.CacheControlFilter</filter-class>
   </filter>
   <filter-mapping>
     <filter-name>CacheControlFilter</filter-name>
@@ -116,6 +121,24 @@
   <servlet-mapping>
     <servlet-name>Tasklist Api</servlet-name>
     <url-pattern>/api/tasklist/*</url-pattern>
+  </servlet-mapping>
+
+  <!-- welcome rest api -->
+  <servlet>
+    <servlet-name>Welcome Api</servlet-name>
+    <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
+    <init-param>
+      <param-name>javax.ws.rs.Application</param-name>
+      <param-value>org.camunda.bpm.welcome.impl.web.WelcomeApplication</param-value>
+    </init-param>
+    <init-param>
+      <param-name>resteasy.servlet.mapping.prefix</param-name>
+      <param-value>/api/welcome</param-value>
+    </init-param>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>Welcome Api</servlet-name>
+    <url-pattern>/api/welcome/*</url-pattern>
   </servlet-mapping>
 
   <!-- engine rest api (embedded) -->

--- a/src/main/webapp/WEB-INF/securityFilterRules.json
+++ b/src/main/webapp/WEB-INF/securityFilterRules.json
@@ -4,7 +4,8 @@
       { "path": "/api/engine/.*", "methods" : "*" },
       { "path": "/api/cockpit/.*", "methods" : "*" },
       { "path": "/app/tasklist/{engine}/.*", "methods" : "*" },
-      { "path": "/app/cockpit/{engine}/.*", "methods" : "*" }
+      { "path": "/app/cockpit/{engine}/.*", "methods" : "*" },
+      { "path": "/app/welcome/{engine}/.*", "methods" : "*" }
     ],
     "allowedPaths" : [
       { "path": "/api/engine/engine/", "methods" : "GET" },
@@ -12,7 +13,8 @@
       { "path": "/api/{app:cockpit}/plugin/{plugin}/{engine}/.*", "methods" : "*", "authorizer" : "org.camunda.bpm.webapp.impl.security.filter.EngineRequestAuthorizer" },
       { "path": "/api/engine/engine/{engine}/.*", "methods" : "*", "authorizer" : "org.camunda.bpm.webapp.impl.security.filter.EngineRequestAuthorizer" },
       { "path": "/app/{app:cockpit}/{engine}/.*", "methods" : "*", "authorizer" : "org.camunda.bpm.webapp.impl.security.filter.ApplicationRequestAuthorizer" },
-      { "path": "/app/{app:tasklist}/{engine}/.*", "methods" : "*", "authorizer" : "org.camunda.bpm.webapp.impl.security.filter.ApplicationRequestAuthorizer" }
+      { "path": "/app/{app:tasklist}/{engine}/.*", "methods" : "*", "authorizer" : "org.camunda.bpm.webapp.impl.security.filter.ApplicationRequestAuthorizer" },
+      { "path": "/app/{app:welcome}/{engine}/.*", "methods" : "*", "authorizer" : "org.camunda.bpm.webapp.impl.security.filter.ApplicationRequestAuthorizer" }
     ]
   }
 }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -125,6 +125,24 @@
     <url-pattern>/api/tasklist/*</url-pattern>
   </servlet-mapping>
 
+  <!-- welcome rest api -->
+  <servlet>
+    <servlet-name>Welcome Api</servlet-name>
+    <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
+    <init-param>
+      <param-name>javax.ws.rs.Application</param-name>
+      <param-value>org.camunda.bpm.welcome.impl.web.WelcomeApplication</param-value>
+    </init-param>
+    <init-param>
+      <param-name>resteasy.servlet.mapping.prefix</param-name>
+      <param-value>/api/welcome</param-value>
+    </init-param>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>Welcome Api</servlet-name>
+    <url-pattern>/api/welcome/*</url-pattern>
+  </servlet-mapping>
+
   <!-- engine rest api (embedded) -->
   <servlet>
     <servlet-name>Engine Api</servlet-name>


### PR DESCRIPTION
After building and deploying the project on WildFly 10 there was an error: Error processing request.
(URI: http://localhost:8080/camunda/app/welcome/default/)

> Context Path:/camunda
Servlet Path:/app/welcome/default/
Path Info:null
Query String:null
Stack Trace
java.lang.RuntimeException: java.lang.NullPointerException
org.camunda.bpm.webapp.impl.security.auth.AuthenticationFilter$1.execute(AuthenticationFilter.java:61)
org.camunda.bpm.webapp.impl.security.auth.AuthenticationFilter$1.execute(AuthenticationFilter.java:56)
org.camunda.bpm.webapp.impl.security.SecurityActions.runWithAuthentications(SecurityActions.java:38)
org.camunda.bpm.webapp.impl.security.auth.AuthenticationFilter.doFilter(AuthenticationFilter.java:56)
io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:60)
io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:84)
io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
org.wildfly.extension.undertow.security.SecurityContextAssociationHandler.handleRequest(SecurityContextAssociationHandler.java:78)
io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131)
io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
io.undertow.security.handlers.NotificationReceiverHandler.handleRequest(NotificationReceiverHandler.java:50)
io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:61)
io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:284)
io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:263)
io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:81)
io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:174)
io.undertow.server.Connectors.executeRootHandler(Connectors.java:202)
io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:793)
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
java.lang.Thread.run(Thread.java:745)