### PR TITLE
#CAM-10609 Vulnerable javascript library: jQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dmn-js": "6.3.3",
     "dom4": "2.1.5",
     "events": "3.0.0",
-    "jquery": "3.3.1",
+    "jquery": "3.4.1",
     "jquery-ui": "1.12.1",
     "mousetrap": "1.6.3",
     "requirejs": "2.3.6",


### PR DESCRIPTION
#CAM-10609 Vulnerable javascript library: jQuery
version: 3.3.1
Details:
CVE-2019-11358: jQuery versions below 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution. An unsanitized
source object containing an enumerable __proto__ property could extend the native Object.prototype. 

Please refer following resources for more details: https://blog.jquery.com/2019/04/10/jquery-3-4-0-
released/, https://nvd.nist.gov/vuln/detail/CVE-2019-11358, https://github.com/jquery/jquery/commit/753d591aea698e57d6db58c9f722cd0808619b1b,

Found on the following pages (only first 10 pages are reported):
https://***/camunda/app/admin/default/#/groups
https://***/camunda/app/welcome/styles/
https://***/camunda/app/cockpit/styles/
https://***/camunda/app/tasklist/styles/
https://***/camunda/app/admin/styles/#/groups
https://***/camunda/app/admin/styles/#/tenants
https://***/camunda/app/admin/styles/#/users
https://***/camunda/app/admin/scripts/#/tenants
https://***/camunda/app/admin/scripts/#/users

Solutions :
Need to upgrade Jquery version from 3.3.1 to 3.4.1

I updated above solutions in code commit.

Camunda Jira ticket for this issue  :  https://app.camunda.com/jira/browse/CAM-10609   #CAM-10609