### PR TITLE
CAM-10948: fix(welcome): fixed group query for user profile

### DIFF
--- a/ui/welcome/client/scripts/directives/user-profile.js
+++ b/ui/welcome/client/scripts/directives/user-profile.js
@@ -56,12 +56,17 @@ module.exports = [
         };
 
         var groupResource = camAPI.resource('group');
-        groupResource.list(function(err, groups) {
-          if (err) {
-            throw err;
+        groupResource.list(
+          {
+            member: $scope.user.id
+          },
+          function(err, groups) {
+            if (err) {
+              throw err;
+            }
+            $scope.user.groups = groups;
           }
-          $scope.user.groups = groups;
-        });
+        );
 
         var userResource = camAPI.resource('user');
         userResource.profile(


### PR DESCRIPTION
As logged in user, in the user profile section of the welcome page I want to see only the groups I am a member of.

The behaviour before this fix has been as follows:
- in the profile section you have shown all existent groups. 
- in case authorization is enabled, you have shown all groups where I have READ authorization.
This is completely confusing for the user. E.g. if connected to LDAP/Active directory as camunda admin I would see all groups of the LDAP/Active directory. Which could be a lot of groups. In other cases, e.g. in case I'm member of a readonly group beeing authorized to see all groups it would be the same. You'll find more confusing cases.
- The current implementation doesn't separate the aspect "I'm member of group X" and "I'm authorized to see group X".

The first step is to correct the query of the welcome page content. See this pull request. Logged in as jonny1 the result will be as follows:

![grafik](https://user-images.githubusercontent.com/46752596/67840225-a42f3700-faf5-11e9-9db5-9c3820056e3f.png)

Authorization rights are a separate concern. 

- If you think a user should always see his own groups, independent from authorization, this would be part of the identity provider implementation. 

Definitely the query of the user profile section should restrict the group query and only retrieve groups where the logged in user is a member of.

Cheers
Gunnar