### PR TITLE
fix(admin): show analytics only for certain users

### DIFF
--- a/ui/admin/client/scripts/pages/analytics.js
+++ b/ui/admin/client/scripts/pages/analytics.js
@@ -54,7 +54,23 @@ module.exports = [
       label: 'TELEMETRY_SETTINGS',
       template: template,
       controller: Controller,
-      priority: 950
+      priority: 950,
+      access: [
+        'AuthorizationResource',
+        function(AuthorizationResource) {
+          return function(cb) {
+            AuthorizationResource.check({
+              permissionName: 'ALL',
+              resourceName: 'authorization',
+              resourceType: 4
+            })
+              .$promise.then(function(response) {
+                cb(null, response.authorized);
+              })
+              .catch(cb);
+          };
+        }
+      ]
     });
   }
 ];


### PR DESCRIPTION
Analytics is only shown when the current user has granted ALL permissions on the Authorization resource. This should only be the case for the admin user.

Related to CAM-12478