### PR TITLE
CAM-12992: chore(engine): command is always implemented as class

### DIFF
--- a/src/main/java/org/camunda/bpm/cockpit/impl/db/QueryServiceImpl.java
+++ b/src/main/java/org/camunda/bpm/cockpit/impl/db/QueryServiceImpl.java
@@ -78,10 +78,6 @@ public class QueryServiceImpl implements QueryService {
     authCheck.setHistoricInstancePermissionsEnabled(isEnableHistoricInstancePermissions);
   }
 
-  /*
-    The Command interface should always be implemented as a regular,
-    or inner class so that invoked commands are correctly counted with Telemetry.
-   */
   protected class QueryServiceRowCountCmd implements Command<Long> {
 
     protected String statement;
@@ -102,10 +98,6 @@ public class QueryServiceImpl implements QueryService {
     }
   }
 
-  /*
-    The Command interface should always be implemented as a regular,
-    or inner class so that invoked commands are correctly counted with Telemetry.
-   */
   protected class ExecuteListQueryCmd<T> implements Command<List<T>> {
 
     protected String statement;
@@ -130,10 +122,6 @@ public class QueryServiceImpl implements QueryService {
     }
   }
 
-  /*
-    The Command interface should always be implemented as a regular,
-    or inner class so that invoked commands are correctly counted with Telemetry.
-   */
   protected class ExecuteSingleQueryCmd<T> implements Command<T> {
 
     protected String statement;

--- a/src/main/java/org/camunda/bpm/cockpit/impl/db/QueryServiceImpl.java
+++ b/src/main/java/org/camunda/bpm/cockpit/impl/db/QueryServiceImpl.java
@@ -25,6 +25,7 @@ import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.db.AuthorizationCheck;
 import org.camunda.bpm.engine.impl.db.ListQueryParameterObject;
+import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.util.QueryMaxResultsLimitUtil;
 
@@ -37,33 +38,15 @@ public class QueryServiceImpl implements QueryService {
   }
 
   public <T> List<T> executeQuery(final String statement, final QueryParameters<T> parameter) {
-    return commandExecutor.executeCommand(commandContext -> {
-      ProcessEngineConfigurationImpl engineConfig = getProcessEngineConfiguration(commandContext);
-
-      configureAuthCheck(parameter, engineConfig, commandContext);
-
-      if (parameter.isMaxResultsLimitEnabled()) {
-        QueryMaxResultsLimitUtil.checkMaxResultsLimit(parameter.getMaxResults(), engineConfig);
-      }
-
-      return (List<T>) commandContext.getDbSqlSession()
-        .selectList(statement, parameter);
-    });
+    return commandExecutor.executeCommand(new ExecuteListQueryCmd<T>(statement, parameter));
   }
 
   public <T> T executeQuery(final String statement, final Object parameter, final Class<T> clazz) {
-    return commandExecutor.executeCommand(commandContext -> (T) commandContext.getDbSqlSession()
-      .selectOne(statement, parameter));
+    return commandExecutor.executeCommand(new ExecuteSingleQueryCmd<T>(statement, parameter, clazz));
   }
 
   public Long executeQueryRowCount(final String statement, final ListQueryParameterObject parameter) {
-    return commandExecutor.executeCommand(commandContext -> {
-      ProcessEngineConfigurationImpl engineConfig = getProcessEngineConfiguration(commandContext);
-
-      configureAuthCheck(parameter, engineConfig, commandContext);
-
-      return (Long) commandContext.getDbSqlSession().selectOne(statement, parameter);
-    });
+    return commandExecutor.executeCommand(new QueryServiceRowCountCmd(statement, parameter));
   }
 
   protected ProcessEngineConfigurationImpl getProcessEngineConfiguration(
@@ -95,4 +78,77 @@ public class QueryServiceImpl implements QueryService {
     authCheck.setHistoricInstancePermissionsEnabled(isEnableHistoricInstancePermissions);
   }
 
+  /*
+    The Command interface should always be implemented as a regular,
+    or inner class so that invoked commands are correctly counted with Telemetry.
+   */
+  protected class QueryServiceRowCountCmd implements Command<Long> {
+
+    protected String statement;
+    protected ListQueryParameterObject parameter;
+
+    public QueryServiceRowCountCmd(String statement, ListQueryParameterObject parameter) {
+      this.statement = statement;
+      this.parameter = parameter;
+    }
+
+    @Override
+    public Long execute(CommandContext commandContext) {
+      ProcessEngineConfigurationImpl engineConfig = getProcessEngineConfiguration(commandContext);
+
+      configureAuthCheck(parameter, engineConfig, commandContext);
+
+      return (Long) commandContext.getDbSqlSession().selectOne(statement, parameter);
+    }
+  }
+
+  /*
+    The Command interface should always be implemented as a regular,
+    or inner class so that invoked commands are correctly counted with Telemetry.
+   */
+  protected class ExecuteListQueryCmd<T> implements Command<List<T>> {
+
+    protected String statement;
+    protected QueryParameters parameter;
+
+    public ExecuteListQueryCmd(String statement, QueryParameters parameter) {
+      this.statement = statement;
+      this.parameter = parameter;
+    }
+
+    @Override
+    public List<T> execute(CommandContext commandContext) {
+      ProcessEngineConfigurationImpl engineConfig = getProcessEngineConfiguration(commandContext);
+
+      configureAuthCheck(parameter, engineConfig, commandContext);
+
+      if (parameter.isMaxResultsLimitEnabled()) {
+        QueryMaxResultsLimitUtil.checkMaxResultsLimit(parameter.getMaxResults(), engineConfig);
+      }
+
+      return (List<T>) commandContext.getDbSqlSession().selectList(statement, parameter);
+    }
+  }
+
+  /*
+    The Command interface should always be implemented as a regular,
+    or inner class so that invoked commands are correctly counted with Telemetry.
+   */
+  protected class ExecuteSingleQueryCmd<T> implements Command<T> {
+
+    protected String statement;
+    protected Object parameter;
+    protected Class clazz;
+
+    public <T> ExecuteSingleQueryCmd(String statement, Object parameter, Class<T> clazz) {
+      this.statement = statement;
+      this.parameter = parameter;
+      this.clazz = clazz;
+    }
+
+    @Override
+    public T execute(CommandContext commandContext) {
+      return (T) commandContext.getDbSqlSession().selectOne(statement, parameter);
+    }
+  }
 }

--- a/src/main/java/org/camunda/bpm/cockpit/impl/plugin/base/sub/resources/ProcessDefinitionResource.java
+++ b/src/main/java/org/camunda/bpm/cockpit/impl/plugin/base/sub/resources/ProcessDefinitionResource.java
@@ -62,16 +62,8 @@ public class ProcessDefinitionResource extends AbstractPluginResource {
   @Path("/called-process-definitions")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  public List<ProcessDefinitionDto> queryCalledProcessDefinitions(final ProcessDefinitionQueryDto queryParameter) {
-    return getCommandExecutor().executeCommand(new Command<List<ProcessDefinitionDto>>() {
-      public List<ProcessDefinitionDto> execute(CommandContext commandContext) {
-        queryParameter.setParentProcessDefinitionId(id);
-        injectEngineConfig(queryParameter);
-        configureExecutionQuery(queryParameter);
-        queryParameter.disableMaxResultsLimit();
-        return getQueryService().executeQuery("selectCalledProcessDefinitions", queryParameter);
-      }
-    });
+  public List<ProcessDefinitionDto> queryCalledProcessDefinitions(ProcessDefinitionQueryDto queryParameter) {
+    return getCommandExecutor().executeCommand(new QueryCalledProcessDefinitionsCmd(queryParameter));
   }
 
   private void injectEngineConfig(ProcessDefinitionQueryDto parameter) {
@@ -91,4 +83,25 @@ public class ProcessDefinitionResource extends AbstractPluginResource {
     addPermissionCheck(query, PROCESS_DEFINITION, "PROCDEF.KEY_", READ_INSTANCE);
   }
 
+  /*
+    The Command interface should always be implemented as a regular,
+    or inner class so that invoked commands are correctly counted with Telemetry.
+   */
+  protected class QueryCalledProcessDefinitionsCmd implements Command<List<ProcessDefinitionDto>> {
+
+    protected ProcessDefinitionQueryDto queryParameter;
+
+    public QueryCalledProcessDefinitionsCmd(ProcessDefinitionQueryDto queryParameter) {
+      this.queryParameter = queryParameter;
+    }
+
+    @Override
+    public List<ProcessDefinitionDto> execute(CommandContext commandContext) {
+      queryParameter.setParentProcessDefinitionId(id);
+      injectEngineConfig(queryParameter);
+      configureExecutionQuery(queryParameter);
+      queryParameter.disableMaxResultsLimit();
+      return getQueryService().executeQuery("selectCalledProcessDefinitions", queryParameter);
+    }
+  }
 }

--- a/src/main/java/org/camunda/bpm/cockpit/impl/plugin/base/sub/resources/ProcessDefinitionResource.java
+++ b/src/main/java/org/camunda/bpm/cockpit/impl/plugin/base/sub/resources/ProcessDefinitionResource.java
@@ -83,10 +83,6 @@ public class ProcessDefinitionResource extends AbstractPluginResource {
     addPermissionCheck(query, PROCESS_DEFINITION, "PROCDEF.KEY_", READ_INSTANCE);
   }
 
-  /*
-    The Command interface should always be implemented as a regular,
-    or inner class so that invoked commands are correctly counted with Telemetry.
-   */
   protected class QueryCalledProcessDefinitionsCmd implements Command<List<ProcessDefinitionDto>> {
 
     protected ProcessDefinitionQueryDto queryParameter;

--- a/src/main/java/org/camunda/bpm/cockpit/impl/plugin/resources/ProcessInstanceRestService.java
+++ b/src/main/java/org/camunda/bpm/cockpit/impl/plugin/resources/ProcessInstanceRestService.java
@@ -133,10 +133,6 @@ public class ProcessInstanceRestService extends AbstractPluginResource {
     this.objectMapper = objectMapper;
   }
 
-  /*
-    The Command interface should always be implemented as a regular,
-    or inner class so that invoked commands are correctly counted with Telemetry.
-   */
   protected class QueryProcessInstancesCmd implements Command<List<ProcessInstanceDto>> {
 
     protected ProcessInstanceQueryDto queryParameter;
@@ -159,10 +155,6 @@ public class ProcessInstanceRestService extends AbstractPluginResource {
     }
   }
 
-  /*
-    The Command interface should always be implemented as a regular,
-    or inner class so that invoked commands are correctly counted with Telemetry.
-   */
   protected class QueryProcessInstancesCountCmd implements Command<CountResultDto> {
 
     protected ProcessInstanceQueryDto queryParameter;

--- a/src/main/java/org/camunda/bpm/cockpit/impl/plugin/resources/ProcessInstanceRestService.java
+++ b/src/main/java/org/camunda/bpm/cockpit/impl/plugin/resources/ProcessInstanceRestService.java
@@ -74,19 +74,10 @@ public class ProcessInstanceRestService extends AbstractPluginResource {
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  public List<ProcessInstanceDto> queryProcessInstances(final ProcessInstanceQueryDto queryParameter,
-      final @QueryParam("firstResult") Integer firstResult, final @QueryParam("maxResults") Integer maxResults) {
+  public List<ProcessInstanceDto> queryProcessInstances(ProcessInstanceQueryDto queryParameter,
+      @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults) {
 
-    return getCommandExecutor().executeCommand(new Command<List<ProcessInstanceDto>>() {
-      public List<ProcessInstanceDto> execute(CommandContext commandContext) {
-        injectObjectMapper(queryParameter);
-        injectEngineConfig(queryParameter);
-        paginate(queryParameter, firstResult, maxResults);
-        configureExecutionQuery(queryParameter);
-        return getQueryService().executeQuery("selectRunningProcessInstancesIncludingIncidents", queryParameter);
-      }
-    });
-
+    return getCommandExecutor().executeCommand(new QueryProcessInstancesCmd(queryParameter, firstResult, maxResults));
   }
 
   @GET
@@ -101,17 +92,9 @@ public class ProcessInstanceRestService extends AbstractPluginResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("/count")
-  public CountResultDto queryProcessInstancesCount(final ProcessInstanceQueryDto queryParameter) {
+  public CountResultDto queryProcessInstancesCount(ProcessInstanceQueryDto queryParameter) {
 
-    return getCommandExecutor().executeCommand(new Command<CountResultDto>() {
-      public CountResultDto execute(CommandContext commandContext) {
-        injectEngineConfig(queryParameter);
-        configureExecutionQuery(queryParameter);
-        long result = getQueryService().executeQueryRowCount("selectRunningProcessInstancesCount", queryParameter);
-        return new CountResultDto(result);
-      }
-    });
-
+    return getCommandExecutor().executeCommand(new QueryProcessInstancesCountCmd(queryParameter));
   }
 
   private void paginate(ProcessInstanceQueryDto queryParameter, Integer firstResult, Integer maxResults) {
@@ -150,4 +133,50 @@ public class ProcessInstanceRestService extends AbstractPluginResource {
     this.objectMapper = objectMapper;
   }
 
+  /*
+    The Command interface should always be implemented as a regular,
+    or inner class so that invoked commands are correctly counted with Telemetry.
+   */
+  protected class QueryProcessInstancesCmd implements Command<List<ProcessInstanceDto>> {
+
+    protected ProcessInstanceQueryDto queryParameter;
+    protected Integer firstResult;
+    protected Integer maxResults;
+
+    public QueryProcessInstancesCmd(ProcessInstanceQueryDto queryParameter, Integer firstResult, Integer maxResults) {
+      this.queryParameter = queryParameter;
+      this.firstResult = firstResult;
+      this.maxResults = maxResults;
+    }
+
+    @Override
+    public List<ProcessInstanceDto> execute(CommandContext commandContext) {
+      injectObjectMapper(queryParameter);
+      injectEngineConfig(queryParameter);
+      paginate(queryParameter, firstResult, maxResults);
+      configureExecutionQuery(queryParameter);
+      return getQueryService().executeQuery("selectRunningProcessInstancesIncludingIncidents", queryParameter);
+    }
+  }
+
+  /*
+    The Command interface should always be implemented as a regular,
+    or inner class so that invoked commands are correctly counted with Telemetry.
+   */
+  protected class QueryProcessInstancesCountCmd implements Command<CountResultDto> {
+
+    protected ProcessInstanceQueryDto queryParameter;
+
+    public QueryProcessInstancesCountCmd(ProcessInstanceQueryDto queryParameter) {
+      this.queryParameter = queryParameter;
+    }
+
+    @Override
+    public CountResultDto execute(CommandContext commandContext) {
+      injectEngineConfig(queryParameter);
+      configureExecutionQuery(queryParameter);
+      long result = getQueryService().executeQueryRowCount("selectRunningProcessInstancesCount", queryParameter);
+      return new CountResultDto(result);
+    }
+  }
 }


### PR DESCRIPTION
* Ensure that all (runtime) implementations of the Command interface are regular, or inner, classes.

Related to CAM-12992